### PR TITLE
docs: update spec.md to reflect TypeSpec/TypeScript format

### DIFF
--- a/src/spec.md
+++ b/src/spec.md
@@ -2,199 +2,292 @@
 
 ## Introduction
 
-We are using [TinySpec](https://github.com/Ajaxy/tinyspec) for defining our API. Specs live in the [SDK repository](https://github.com/OsomePteLtd/sdk/tree/master/spec). Specs are grouped by domain (`core`, `accounting`, `ecommerce`, etc).
+We use **TypeScript** with `@osomepteltd/typespec` for defining our API specifications. Specs live in the [SDK repository](https://github.com/OsomePteLtd/sdk/tree/master/spec). Specs are grouped by domain (`core`, `accounting`, `payment`, `bank`, etc).
+
+Files use the `.ts` extension and are organized as:
+
+- `spec/{domain}/{feature}.ts` - Feature-specific types and endpoints
+- `spec/{domain}/index.ts` - Service definition and controller exports
+- `spec/shared/` - Shared types across domains
+
+Example structure:
+
+```
+spec/payment/intent.ts          # Intent types and endpoints
+spec/payment/customerSession.ts # Customer session types
+spec/payment/index.ts           # Payot service definition
+spec/bank/connection.ts         # Bank connection types and endpoints
+```
 
 We have 3 types of specs:
 
-- `common` – for both agents and clients
-- `agent` – only for agents
-- `client` – only for clients
+- `common` - for both agents and clients (default)
+- `agent` - only for agents (use `agent()` wrapper)
+- `client` - only for clients
 
-File names for an entity should have the following form:
+## Core Imports
 
-- `spec/${domain}/endpoints/${entity}.${type}.endpoints.tinyspec`
-- `spec/${domain}/models/${entity}.${type}.models.tinyspec`
-
-Example:
-
-- `spec/bank/endpoints/connection.common.endpoints.tinyspec`
-- `spec/bank/models/connection.common.models.tinyspec`
+```typescript
+import {
+  array,
+  b,              // boolean
+  controller,
+  d,              // date
+  endpoint,
+  enumerable,
+  extend,
+  f,              // float
+  i,              // integer
+  nullable,
+  o,              // object
+  optional,
+  request,
+  s,              // string
+  shape,
+  t,              // timestamp
+} from '@osomepteltd/typespec';
+```
 
 ## Index Endpoints
 
 Example:
 
-```
-GET /bank/connections?BkConnectionIndexRequestQuery
-  => BkConnectionListResponse
+```typescript
+'get-connections': endpoint({
+  http: { method: 'get', path: '/bank/connections' },
+  request: request({
+    queryStringParameters: shape(
+      { filter: BkConnectionFilter },
+      { synonyms: ['BkConnectionIndexRequestQuery'] },
+    ),
+    synonyms: ['BkConnectionIndexRequest'],
+  }),
+  response: BkConnectionListResponse,
+}),
 ```
 
-```
-BkConnection !{
+Type definitions:
+
+```typescript
+export const BkConnectionStatus = enumerable(['active', 'disconnected']);
+
+export const BkConnection = shape({
   id: i,
-  createdAt: d,
-  updatedAt: d,
+  createdAt: t,
+  updatedAt: t,
   companyId: i,
   status: BkConnectionStatus,
-  company?: Company,
-}
+  company: optional(Company),
+});
 
-BkConnectionStatus (
-  active |
-  disconnected
-)
+export const BkConnectionFilter = shape({
+  companyId: optional(nullable(i)),
+  statuses: optional(nullable(array(BkConnectionStatus))),
+});
 
-BkConnectionFilter !{
-  companyId: i,
-}
-
-BkConnectionInclude (
-  company
-)
-
-BkConnectionIndexRequest {
-  queryStringParameters: BkConnectionIndexRequestQuery,
-}
-
-BkConnectionIndexRequestQuery !{
-  filter: BkConnectionFilter,
-  include?: BkConnectionInclude[],
-}
-
-BkConnectionListResponse !{
-  connections: BkConnection[],
-}
-
-// paginated version
-BkConnectionListResponse < PaginatedResponse !{
-  connections: BkConnection[],
-}
+export const BkConnectionListResponse = shape({ connections: array(BkConnection) });
 ```
 
 Here we have the following names:
 
-- `${Entity}` – for the entity
-- `${Entity}Filter` – for the filter parameters
-- `${Entity}Include` – for the include parameters
-- `${Entity}IndexRequest` – for the "index" request
-- `${Entity}IndexRequestQuery` – for the "index" query string parameters
-- `${Entity}ListResponse` – for the list response body. For paginated responses, inherit from the shared `PaginatedResponse` model.
+- `${Entity}` - for the entity
+- `${Entity}Filter` - for the filter parameters
+- `${Entity}IndexRequest` - for the "index" request (via synonyms)
+- `${Entity}IndexRequestQuery` - for the "index" query string parameters (via synonyms)
+- `${Entity}ListResponse` - for the list response body
 
 ## Create Endpoints
 
 Example:
 
-```
-POST /bank/connections BkConnectionCreateRequestBody
-  => BkConnectionResponse
+```typescript
+'create-connection': endpoint({
+  http: { method: 'post', path: '/bank/connections' },
+  request: request({ body: BkConnectionCreateRequestBody }),
+  response: BkConnectionResponse,
+}),
 ```
 
-```
-BkConnectionNew !{
+Type definitions:
+
+```typescript
+export const BkConnectionNew = shape({
   companyId: i,
-  publicToken,
-}
+  publicToken: optional(nullable(s)),
+  provider: BkConnectionProvider,
+});
 
-BkConnectionCreateRequest {
-  body: BkConnectionCreateRequestBody,
-}
-
-BkConnectionCreateRequestBody !{
-  connection: BkConnectionNew,
-}
-
-BkConnectionResponse !{
-  connection: BkConnection,
-}
+export const BkConnectionCreateRequestBody = shape({ connection: BkConnectionNew });
+export const BkConnectionResponse = shape({ connection: BkConnection });
 ```
 
 Here we added the following names:
 
-- `${Entity}New` – for the parameters to create an entity
-- `${Entity}CreateRequest` – for the "create" request
-- `${Entity}CreateRequestBody` – for the "create" request body
-- `${Entity}Response` – for the entity response body
+- `${Entity}New` - for the parameters to create an entity
+- `${Entity}CreateRequestBody` - for the "create" request body
+- `${Entity}Response` - for the entity response body
 
 ## Get Endpoints
 
 Example:
 
-```
-GET /bank/connections/:id:i
-  => BkConnectionResponse
-```
-
-```
-BkConnectionRequest {
-  pathParameters: !{
-    id: i,
-  }
-}
-
-BkConnectionGetRequest < BkConnectionRequest {}
+```typescript
+'get-connection': endpoint({
+  http: { method: 'get', path: '/bank/connections/{id}' },
+  request: BkConnectionRequest,
+  response: BkConnectionResponse,
+}),
 ```
 
-Here we added the following names:
+Type definitions:
 
-- `${Entity}Request` – for the base entity request
-- `${Entity}GetRequest` – for the "get" request
+```typescript
+export const BkConnectionRequest = request({ pathParameters: { id: i } });
+```
+
+Here we added the following name:
+
+- `${Entity}Request` - for the base entity request with path parameters
 
 ## Update Endpoints
 
 Example:
 
-```
-PATCH /bank/connections/:id:i BkConnectionUpdateRequestBody
-  => BkConnectionResponse
+```typescript
+'update-connection': endpoint({
+  http: { method: 'patch', path: '/bank/connections/{id}' },
+  request: request({
+    pathParameters: { id: i },
+    body: BkConnectionUpdateRequestBody,
+  }),
+  response: BkConnectionResponse,
+}),
 ```
 
-```
-BkConnectionUpdate !{
-  status?: BkConnectionStatus,
-}
+Type definitions:
 
-BkConnectionUpdateRequest < BkConnectionRequest {
-  body: BkConnectionUpdateRequestBody,
-}
+```typescript
+export const BkConnectionUpdate = shape({
+  status: optional(BkConnectionStatus),
+});
 
-BkConnectionUpdateRequestBody !{
-  connection: BkConnectionUpdate,
-}
+export const BkConnectionUpdateRequestBody = shape({ connection: BkConnectionUpdate });
 ```
 
 Here we added the following names:
 
-- `${Entity}Update` – for the parameters to update an entity
-- `${Entity}UpdateRequest` – for the "update" request
-- `${Entity}UpdateRequestBody` – for the "update" request body
+- `${Entity}Update` - for the parameters to update an entity
+- `${Entity}UpdateRequestBody` - for the "update" request body
 
 ## Delete Endpoints
 
 Example:
 
+```typescript
+'delete-connection': endpoint({
+  http: { method: 'delete', path: '/bank/connections/{id}' },
+  request: BkConnectionRequest,
+  // No response = 204 status code
+}),
 ```
-DELETE /bank/connections/:id:i
-  => 204
+
+Omit the `response` field to indicate a 204 status code with no content.
+
+## Controller Pattern
+
+Group endpoints into a controller:
+
+```typescript
+export const connection = controller({
+  endpoints: {
+    'get-connections': endpoint({ ... }),
+    'get-connection': endpoint({ ... }),
+    'create-connection': endpoint({ ... }),
+    'update-connection': endpoint({ ... }),
+    'delete-connection': endpoint({ ... }),
+  },
+});
 ```
 
+## Service Index
+
+Register controllers in the service index file (`index.ts`):
+
+```typescript
+import { service } from '@osomepteltd/typespec';
+import { connection } from './connection';
+import { account } from './account';
+
+export const scrooge = service({
+  prefix: 'Bk',
+  controllers: {
+    connection,
+    account,
+  },
+});
 ```
-BkConnectionDeleteRequest < BkConnectionRequest {}
+
+## Service Prefixes
+
+| Prefix | Domain     | Service       |
+| ------ | ---------- | ------------- |
+| `Ac`   | accounting | pablo, skyler |
+| `Bk`   | bank       | scrooge       |
+| `Bi`   | billing    | billy         |
+| `Co`   | corpsec    | hermes        |
+| `Pt`   | payment    | payot         |
+| `In`   | invoicing  | invoker       |
+| `Ec`   | ecommerce  | shiva         |
+
+## Agent-Only Fields
+
+Use the `agent()` wrapper for fields only exposed to agent apps:
+
+```typescript
+import { agent } from '../shared';
+
+export const BkConnectionFilter = shape({
+  companyId: optional(nullable(i)),
+  companyIds: agent(optional(nullable(array(i)))), // Only for agents
+});
 ```
 
-Here we added the following name:
+## Zod-based Schemas (Alternative Pattern)
 
-- `${Entity}DeleteRequest` – for the "delete" request
+For OpenAPI integration, some specs use Zod directly:
 
-Specify `204` status code if your endpoint is not returning any content.
+```typescript
+import { extendApi } from '@anatine/zod-openapi';
+import { z } from 'zod';
 
+export const PtCustomerSessionRequestPath = z.object({
+  customerId: z.string().openapi({
+    description: 'Stripe customer ID',
+    example: 'cus_1234567890',
+  }),
+});
+
+export const PtCustomerSessionResponse = z.object({
+  customerSessionClientSecret: z.string().openapi({
+    description: 'Stripe customer session client secret',
+  }),
+});
+
+// Type exports
+export type PtCustomerSessionResponse = z.infer<typeof PtCustomerSessionResponse>;
 ```
-// deprecated
 
-DELETE /bank/connections/:id:i
-  => SuccessResponse
+## Naming Conventions Summary
 
-// good
-
-DELETE /bank/connections/:id:i
-  => 204
-```
+| Pattern                              | Usage                  | Example                         |
+| ------------------------------------ | ---------------------- | ------------------------------- |
+| `${Prefix}${Entity}`                 | Entity type            | `BkConnection`, `PtIntent`      |
+| `${Prefix}${Entity}Status`           | Status enum            | `BkConnectionStatus`            |
+| `${Prefix}${Entity}Filter`           | Filter params          | `BkConnectionFilter`            |
+| `${Prefix}${Entity}New`              | Create params          | `BkConnectionNew`               |
+| `${Prefix}${Entity}Update`           | Update params          | `BkConnectionUpdate`            |
+| `${Prefix}${Entity}Request`          | Base request           | `BkConnectionRequest`           |
+| `${Prefix}${Entity}Response`         | Single entity response | `BkConnectionResponse`          |
+| `${Prefix}${Entity}ListResponse`     | List response          | `BkConnectionListResponse`      |
+| `${Prefix}${Entity}CreateRequestBody`| Create body            | `BkConnectionCreateRequestBody` |
+| `${Prefix}${Entity}UpdateRequestBody`| Update body            | `BkConnectionUpdateRequestBody` |


### PR DESCRIPTION
## Summary
- Update API specification documentation from TinySpec to TypeSpec/TypeScript format

## Changes
- Replace `.tinyspec` file references with `.ts`
- Update code examples to use `@osomepteltd/typespec` patterns
- Add controller/endpoint definition examples from actual SDK
- Add Zod-based schema alternative pattern
- Update naming conventions table
- Add service prefixes reference

## Why
The SDK repository has evolved to use TypeScript files with `@osomepteltd/typespec` instead of the legacy TinySpec format. This documentation update ensures consistency between principles documentation and actual SDK implementation.

## References
- SDK repo structure: `sdk/spec/`
- Example files: `spec/bank/connection.ts`, `spec/payment/intent.ts`