### PR TITLE
docs(frontend): add strict equality convention for null/undefined checks

### DIFF
--- a/src/frontend.md
+++ b/src/frontend.md
@@ -160,6 +160,25 @@ Notes:
    };
    ```
 
+1. Use strict equality (`===` / `!==`) for `null` and `undefined` checks. Never use loose equality (`== null`) even though it catches both `null` and `undefined` — it obscures intent and is inconsistent with our codebase patterns.
+
+   ```typescript
+   // bad — loose equality is ambiguous
+   if (value == null) {
+     return;
+   }
+
+   // good — explicit about what you're checking
+   if (value === null) {
+     return;
+   }
+
+   // good — when you need to check both null and undefined, be explicit
+   if (value === null || value === undefined) {
+     return;
+   }
+   ```
+
 ## SDK
 
 1. Avoid `as` keyword for importing types from sdk


### PR DESCRIPTION
## Summary
- Add TypeScript convention requiring strict equality (`===`/`!==`) for null and undefined checks
- Explicitly forbids loose equality (`== null`) even though it's a known JS idiom

## Why
- Our codebases overwhelmingly use explicit strict checks (e.g. `=== null || === undefined`)
- Loose equality obscures developer intent and relies on JS coercion quirks
- Consistency is more important than brevity

## Related
- https://github.com/OsomePteLtd/websome-invoices/pull/2376